### PR TITLE
Record dependency on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=['cryptography>=3.4.7', 'pyserial', 'netifaces>=0.10.4'],
+    install_requires=['cryptography>=3.4.7', 'pyserial', 'netifaces>=0.10.4', 'six'],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
Because this exists: https://github.com/markqvist/Reticulum/blob/master/RNS/vendor/configobj.py#L22