### PR TITLE
OSX NameError fix

### DIFF
--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -112,8 +112,8 @@ class TCPClientInterface(Interface):
         else:
             TCP_KEEPIDLE = 0x10
 
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPIDLE, int(TCPClientInterface.TCP_PROBE_AFTER))
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        self.socket.setsockopt(socket.IPPROTO_TCP, TCP_KEEPIDLE, int(TCPClientInterface.TCP_PROBE_AFTER))
 
     def detach(self):
         if self.socket != None:


### PR DESCRIPTION
Had the following error when trying to run Reticulum on OSX High Sierra:
```
line 115, in set_timeouts_osx
    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
NameError: name 'sock' is not defined
```
This fix solved the problem for me.
(Also git added the newline at the end of the file, not sure if no-newline at EOF is intentional or not)