### PR TITLE
Fix bug where announce_identity could be undefined

### DIFF
--- a/RNS/Transport.py
+++ b/RNS/Transport.py
@@ -1427,12 +1427,12 @@ class Transport:
                                         # Check that the announced destination matches
                                         # the handlers aspect filter
                                         execute_callback = False
+                                        announce_identity = RNS.Identity.recall(packet.destination_hash)
                                         if handler.aspect_filter == None:
                                             # If the handlers aspect filter is set to
                                             # None, we execute the callback in all cases
                                             execute_callback = True
                                         else:
-                                            announce_identity = RNS.Identity.recall(packet.destination_hash)
                                             handler_expected_hash = RNS.Destination.hash_from_name_and_identity(handler.aspect_filter, announce_identity)
                                             if packet.destination_hash == handler_expected_hash:
                                                 execute_callback = True


### PR DESCRIPTION
Let me preface this by saying that I have no idea if this patch is correct or not and if this is really a bug or I'm doing something wrong ^_^.

I'm trying out the Announce example and I noticed that when I set `aspect_filter` to `None`, the callback would error out with:
```
[2023-01-26 19:50:58] [Error] Error while processing external announce callback.           
[2023-01-26 19:50:58] [Error] The contained exception was: local variable 'announce_identity' referenced before assignment
```
Looking at the codebase, it makes sense since we never assigned the `announce_identity` variable. We're only assigning it if `aspect_filter` is not `None`, but I think we should be assigning it regardless of `aspect_filter`'s value.

if this isn't a bug, is there something else I'm missing?