### PR TITLE
hkdf: Remove duplicate check if the salt is None

### DIFF
--- a/RNS/Cryptography/HKDF.py
+++ b/RNS/Cryptography/HKDF.py
@@ -39,9 +39,6 @@ def hkdf(length=None, derive_from=None, salt=None, context=None):
     if salt == None or len(salt) == 0:
         salt = bytes([0] * hash_len)
 
-    if salt == None:
-        salt = b""
-
     if context == None:
         context = b""
 


### PR DESCRIPTION
I started looking into the IFAC parts a bit more closely which led me to this.

The second if isn't needed since we initialize the salt with zeroes earlier. If instead we meant to pass an empty bytes class to the HMAC implementation, the end result would be the same, since it's gonna get padded with zeroes in the HMAC code.