### PR TITLE
Bugfix: buffer missing segments

### DIFF
--- a/RNS/Channel.py
+++ b/RNS/Channel.py
@@ -357,7 +357,7 @@ class Channel(contextlib.AbstractContextManager):
             with self._lock:
                 message = envelope.unpack(self._message_factories)
                 prev_env = self._rx_ring[0] if len(self._rx_ring) > 0 else None
-                if prev_env and envelope.sequence != prev_env.sequence + 1:
+                if prev_env and envelope.sequence != (prev_env.sequence + 1) % 0x10000:
                     RNS.log("Channel: Out of order packet received", RNS.LOG_DEBUG)
                     return
                 is_new = self._emplace_envelope(envelope, self._rx_ring)

--- a/RNS/Interfaces/LocalInterface.py
+++ b/RNS/Interfaces/LocalInterface.py
@@ -86,6 +86,8 @@ class LocalClientInterface(Interface):
         self.online  = True
         self.writing = False
 
+        self._force_bitrate = False
+
         self.announce_rate_target  = None
         self.announce_rate_grace   = None
         self.announce_rate_penalty = None
@@ -137,6 +139,9 @@ class LocalClientInterface(Interface):
 
 
     def processIncoming(self, data):
+        if self._force_bitrate:
+            time.sleep(len(data) / self.bitrate * 8)
+
         self.rxb += len(data)
         if hasattr(self, "parent_interface") and self.parent_interface != None:
             self.parent_interface.rxb += len(data)
@@ -154,6 +159,8 @@ class LocalClientInterface(Interface):
         if self.online:
             try:
                 self.writing = True
+                if self._force_bitrate:
+                    time.sleep(len(data) / self.bitrate * 8)
                 data = bytes([HDLC.FLAG])+HDLC.escape(data)+bytes([HDLC.FLAG])
                 self.socket.sendall(data)
                 self.writing = False

--- a/RNS/Link.py
+++ b/RNS/Link.py
@@ -809,9 +809,9 @@ class Link:
                         if not self._channel:
                             RNS.log(f"Channel data received without open channel", RNS.LOG_DEBUG)
                         else:
+                            packet.prove()
                             plaintext = self.decrypt(packet.data)
                             self._channel._receive(plaintext)
-                            packet.prove()
 
                 elif packet.packet_type == RNS.Packet.PROOF:
                     if packet.context == RNS.Packet.RESOURCE_PRF:

--- a/RNS/Transport.py
+++ b/RNS/Transport.py
@@ -882,6 +882,8 @@ class Transport:
             return True
         if packet.context == RNS.Packet.CACHE_REQUEST:
             return True
+        if packet.context == RNS.Packet.CHANNEL:
+            return True
 
         if packet.destination_type == RNS.Destination.PLAIN:
             if packet.packet_type != RNS.Packet.ANNOUNCE:


### PR DESCRIPTION
@markqvist This hopefully resolves the issues you were experiencing. I was able to reproduce similar issues and I think they are retry-related. As part of the fix, I added a protected variable to LocalInterface to allow tests to simulate links with constrained bandwidth. It was my first and ignorant crack at it, do feel free to push back if you don't like it.

I am not certain that the problem was just that the retry timer was too short. It could be additional complications due to half duplex or actual lost packets from the physical channel. I'll need to set up a proper LoRa test rig to really see what's going on with that.

### In this update

- StreamDataMessage now packed by struct rather than umsgpack for a more predictable size
- Added protected variable on LocalInterface to allow tests to simulate a low bandwidth connection
- Retry timer now has exponential backoff and a more sane starting value
- Link proves packet _before_ sending contents to Channel; this should help prevent spurious retries especially on half-duplex links
- Transport packet filter no longer filters out duplicate packets for Channel. Duplicates are handled in Channel to ensure the duplicate packet is reproven (in case the original proof packet was lost)
- Fixed up tests broken by these changes
- Added a low bandwidth buffer test. Since it takes ~2 min to finish, the test is skipped unless `RUN_SLOW_TESTS=1` is specified on the command line.