### PR TITLE
RNodeInterface - Fixed missing init of 'r_stat_snr'.

### DIFF
--- a/RNS/Interfaces/Android/RNodeInterface.py
+++ b/RNS/Interfaces/Android/RNodeInterface.py
@@ -395,6 +395,7 @@ class RNodeInterface(Interface):
         self.r_stat_rx   = None
         self.r_stat_tx   = None
         self.r_stat_rssi = None
+        self.r_stat_snr  = None
         self.r_random    = None
 
         self.packet_queue    = []

--- a/RNS/Interfaces/RNodeInterface.py
+++ b/RNS/Interfaces/RNodeInterface.py
@@ -157,6 +157,7 @@ class RNodeInterface(Interface):
         self.r_stat_rx   = None
         self.r_stat_tx   = None
         self.r_stat_rssi = None
+        self.r_stat_snr  = None
         self.r_random    = None
 
         self.packet_queue    = []


### PR DESCRIPTION
This this will otherwise lead to the error:
AttributeError: 'RNodeInterface' object has no attribute 'r_stat_snr'