### PR TITLE
rnodeconf: Dump eeprom under specific directory

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -237,6 +237,7 @@ try:
     EXT_DIR = CNF_DIR+"/extracted"
     RT_PATH = CNF_DIR+"/recovery_esptool.py"
     TK_DIR  = CNF_DIR+"/trusted_keys"
+    ROM_DIR = CNF_DIR+"/eeprom"
 
     if not os.path.isdir(CNF_DIR):
         os.makedirs(CNF_DIR)
@@ -248,6 +249,8 @@ try:
         os.makedirs(EXT_DIR)
     if not os.path.isdir(TK_DIR):
         os.makedirs(TK_DIR)
+    if not os.path.isdir(ROM_DIR):
+        os.makedirs(ROM_DIR)
 
 except Exception as e:
     print("No access to directory "+str(CNF_DIR)+". This utility needs file system access to store firmware and data files. Cannot continue.")
@@ -2674,7 +2677,7 @@ def main():
                 try:
                     timestamp = time.time()
                     filename = str(time.strftime("%Y-%m-%d_%H-%M-%S"))
-                    path = "./eeprom/"+filename+".eeprom"
+                    path = ROM_DIR + filename + ".eeprom"
                     file = open(path, "wb")
                     file.write(rnode.eeprom)
                     file.close()


### PR DESCRIPTION
The `--eeprom-dump` mechanism tries to dump the eeprom in the current directory under `./eeprom/`, but this fails if the eeprom directory doesn't exist and it's not obvious to the user that they should create this dir.

This patch will instead dump the eeprom under a new directory in `CNF_DIR`, the same same way as all the other dump/extract commands do. Here's an example output of this:

```
(reticulum2) redteamoricono ~/Code/Python/Reticulum % rnodeconf --eeprom-backup /dev/ttyUSB0
[17:09:40] Opening serial port /dev/ttyUSB0...                                                             
[17:09:43] Device connected                                                                                
[17:09:43] Current firmware version: 1.62                                                                  
[17:09:43] Reading EEPROM...                                                                               
[17:09:44] EEPROM checksum correct                   
[17:09:44] Device signature validated                                                                      
[17:09:44] EEPROM backup written to: /home/dgrig/.config/rnodeconf/eeprom2023-08-14_18-09-44.eeprom
```