### PR TITLE
Added suggestion to use lower baudrate if flashing fails on ESP32

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -2467,6 +2467,9 @@ def main():
                                     RNS.log("Waiting for ESP32 reset...")
                                     time.sleep(7)
                             else:
+                                RNS.log("Non-zero return code ("+str(flash_status)+") while flashing")
+                                RNS.log("Try again with slower speeds for example like this:")
+                                RNS.log("rnodeconf --autoinstall --baud-flash 115200")
                                 exit()
 
                         except Exception as e:


### PR DESCRIPTION
As discussed on Matrix not long ago. This just adds a suggestion after rnodeconf fails to flash on ESP32 due to speed issues. T