### PR TITLE
WIP: link: Fix MDU calculation size for Links

### DIFF
--- a/RNS/Link.py
+++ b/RNS/Link.py
@@ -61,7 +61,7 @@ class Link:
     ECPUBSIZE         = 32+32
     KEYSIZE           = 32
 
-    MDU = math.floor((RNS.Reticulum.MTU-RNS.Reticulum.IFAC_MIN_SIZE-RNS.Reticulum.HEADER_MINSIZE-RNS.Identity.FERNET_OVERHEAD)/RNS.Identity.AES128_BLOCKSIZE)*RNS.Identity.AES128_BLOCKSIZE - 1
+    MDU = math.floor((RNS.Reticulum.MDU-RNS.Identity.FERNET_OVERHEAD)/RNS.Identity.AES128_BLOCKSIZE)*RNS.Identity.AES128_BLOCKSIZE - 1
 
     ESTABLISHMENT_TIMEOUT_PER_HOP = RNS.Reticulum.DEFAULT_PER_HOP_TIMEOUT
     """


### PR DESCRIPTION
@faragher reported on Matrix that they had issues when trying to transfer large files (25MB-35MB) in NomadNet, I was able to reproduce this with the following error.

> [2024-01-10 19:32:17] [Error] Could not advertise resource, the contained exception was: Packet size of 515 exceeds MTU of 500 bytes

I took a closer look on the link and advertisement code and noticed that the MDU calculation for Links is wrong. Specifically, we need to substract the HEADER_MAXSIZE instead of MINSIZE to correctly calculate the MDU of a Link. In order to avoid similar mistakes in the future and not duplicate this calculation, I opted to reuse Reticulum.MDU which we should treat as the single point of calculating the base MDU.

Before this patch:
```
>>> import RNS                                                                                                         
>>> RNS.phyparams()                                                                                                    
Required Physical Layer MTU : 500 bytes                                                                                
Plaintext Packet MDU        : 464 bytes                                                                                
Encrypted Packet MDU        : 383 bytes                                                                                                                                                                                                        
Link Curve                  : Curve25519                                                                                                                                                                                                       
Link Packet MDU             : 431 bytes                                                                                                                                                                                                        
Link Public Key Size        : 512 bits                                                                                 
Link Private Key Size       : 256 bits 
```

After the patch:
```
>>> import RNS                                                                                                                                                                                                                            
>>> RNS.phyparams()                                                                                                                                                                                                                          
Required Physical Layer MTU : 500 bytes
Plaintext Packet MDU        : 464 bytes
Encrypted Packet MDU        : 383 bytes
Link Curve                  : Curve25519
Link Packet MDU             : 415 bytes
Link Public Key Size        : 512 bits
Link Private Key Size       : 256 bits
```

I still can't get large file transfers to work, I believe some more wrong calculations might have slipped in some places, but at least this fixes the advertisement part.