### PR TITLE
Ensure Resources have an input_file attribute

### DIFF
--- a/RNS/Resource.py
+++ b/RNS/Resource.py
@@ -204,6 +204,7 @@ class Resource:
         data_size = None
         resource_data = None
         self.assembly_lock = False
+        self.input_file = None
 
         if data != None:
             if not hasattr(data, "read") and len(data) > Resource.MAX_EFFICIENT_SIZE:


### PR DESCRIPTION
After pulling and testing the latest changes in `master`, I ran into an issue when requesting some resources from my node which resulted in the node disconnecting from the testnet. Specifically, rnsd logged:

```
[2024-01-14 22:38:12] [Warning] An interface error occurred for TCPInterface[RNS Testnet Frankfurt/dublin.connect.reticulum.network:4965], the contained exception was: 'Resource' object has no attribute 'input_file'
[2024-01-14 22:38:12] [Warning] Attempting to reconnect... 
```

I believe this was introduced in ae1d962b9ba5915501272e69377766b99feb799d. Making sure that all Resource objects have an `input_file` attribute seems to solve this.