### PR TITLE
Support for alternate download URL for custom firmware images

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -999,83 +999,85 @@ def ensure_firmware_file(fw_filename):
 
     else:
         try:
-            if selected_version == None:
-                if not upd_nocheck:
-                    try:
-                        try:
-                            # if custom firmware url, download latest release
-                            if fw_url != None:
-                                try:
-                                    RNS.log("Retrieving latest version from custom url "+fw_url+"latest/download/release.json")
-                                    urlretrieve(fw_url+"latest/download/release.json", UPD_DIR+"/fallback_release_info.json")
-                                    import json
-                                    with open(UPD_DIR+"/fallback_release_info.json", "rb") as rif:
-                                        rdat = json.loads(rif.read())
-                                        variant = rdat[fw_filename]
-                                        with open(UPD_DIR+"/"+fw_filename+".version.latest", "wb") as verf:
-                                            inf_str = str(variant["version"])+" "+str(variant["hash"])
-                                            verf.write(inf_str.encode("utf-8"))
-
-                                except Exception as e:
-                                    RNS.log("Error while trying custom URL: "+str(e))
-                                    raise e
+            if not upd_nocheck:
+                try:
+                    # if custom firmware url, download latest release
+                    if selected_version == None and fw_url == None:
+                        version_url = firmware_version_url+fw_filename
+                        RNS.log("Retrieving latest version info from "+version_url)
+                        urlretrieve(firmware_version_url+fw_filename, UPD_DIR+"/"+fw_filename+".version.latest")
+                    else:
+                        if fw_url != None:
+                            if selected_version == None:
+                                version_url = fw_url+"latest/download/release.json"
                             else:
-                                urlretrieve(firmware_version_url+fw_filename, UPD_DIR+"/"+fw_filename+".version.latest")
+                                version_url = fw_url+"download/"+selected_version+"/release.json"
+                        else:
+                                version_url = firmware_update_url+selected_version+"/release.json"
+                        try:
+                            RNS.log("Retrieving specified version info from "+version_url)
+                            urlretrieve(version_url, UPD_DIR+"/version_release_info.json")
+                            import json
+                            with open(UPD_DIR+"/version_release_info.json", "rb") as rif:
+                                rdat = json.loads(rif.read())
+                                variant = rdat[fw_filename]
+                                with open(UPD_DIR+"/"+fw_filename+".version.latest", "wb") as verf:
+                                    inf_str = str(variant["version"])+" "+str(variant["hash"])
+                                    verf.write(inf_str.encode("utf-8"))
                         except Exception as e:
-                            # if custom firmware url, don't fallback
-                            if fw_url != None:
-                                RNS.log("Failed to retrive latest version information for your board from the specified url.")
-                                RNS.log("Check your internet connection and try again.")
-                                RNS.log("If you don't have Internet access currently, use the --fw-version option to manually specify a version.")
-                                RNS.log("You can also use --extract to copy the firmware from a known-good RNode of the same model.")
-                                exit()
-
-                            RNS.log("")
-                            RNS.log("WARNING!")
-                            RNS.log("Failed to retrieve latest version information for your board from the default server")
-                            RNS.log("Will retry using the following fallback URL: "+fallback_firmware_version_url)
-                            RNS.log("")
-                            RNS.log("Hit enter if you want to proceed")
-                            input()
-                            try:
-                                urlretrieve(fallback_firmware_version_url, UPD_DIR+"/fallback_release_info.json")
-                                import json
-                                with open(UPD_DIR+"/fallback_release_info.json", "rb") as rif:
-                                    rdat = json.loads(rif.read())
-                                    variant = rdat[fw_filename]
-                                    with open(UPD_DIR+"/"+fw_filename+".version.latest", "wb") as verf:
-                                        inf_str = str(variant["version"])+" "+str(variant["hash"])
-                                        verf.write(inf_str.encode("utf-8"))
-
-                            except Exception as e:
-                                RNS.log("Error while trying fallback URL: "+str(e))
-                                raise e
-
-                    except Exception as e:
-                        RNS.log("Failed to retrive latest version information for your board.")
+                            RNS.log("Failed to retrive version information for your board.")
+                            RNS.log("Check your internet connection and try again.")
+                            RNS.log("If you don't have Internet access currently, use the --fw-version option to manually specify a version.")
+                            RNS.log("You can also use --extract to copy the firmware from a known-good RNode of the same model.")
+                            exit()
+                except Exception as e:
+                    # if custom firmware url, don't fallback
+                    if fw_url != None:
+                        RNS.log("Failed to retrive version information for your board from the specified url.")
                         RNS.log("Check your internet connection and try again.")
                         RNS.log("If you don't have Internet access currently, use the --fw-version option to manually specify a version.")
                         RNS.log("You can also use --extract to copy the firmware from a known-good RNode of the same model.")
                         exit()
 
-                    import shutil
-                    file = open(UPD_DIR+"/"+fw_filename+".version.latest", "rb")
-                    release_info = file.read().decode("utf-8").strip()
-                    selected_version = release_info.split()[0]
-                    if selected_version == "not":
-                        RNS.log("No valid version found for this board, exiting.")
-                        exit(199)
+                    RNS.log("")
+                    RNS.log("WARNING!")
+                    RNS.log("Failed to retrieve latest version information for your board from the default server.")
+                    RNS.log("Will retry using the following fallback URL: "+fallback_firmware_version_url)
+                    RNS.log("")
+                    RNS.log("Hit enter if you want to proceed")
+                    input()
+                    try:
+                        urlretrieve(fallback_firmware_version_url, UPD_DIR+"/fallback_release_info.json")
+                        import json
+                        with open(UPD_DIR+"/fallback_release_info.json", "rb") as rif:
+                            rdat = json.loads(rif.read())
+                            variant = rdat[fw_filename]
+                            with open(UPD_DIR+"/"+fw_filename+".version.latest", "wb") as verf:
+                                inf_str = str(variant["version"])+" "+str(variant["hash"])
+                                verf.write(inf_str.encode("utf-8"))
 
-                    selected_hash = release_info.split()[1]
-                    if not os.path.isdir(UPD_DIR+"/"+selected_version):
-                        os.makedirs(UPD_DIR+"/"+selected_version)
-                    shutil.copy(UPD_DIR+"/"+fw_filename+".version.latest", UPD_DIR+"/"+selected_version+"/"+fw_filename+".version")
-                    RNS.log("The latest firmware for this board is version "+selected_version)
+                    except Exception as e:
+                        RNS.log("Error while trying fallback URL: "+str(e))
+                        raise e
 
-                else:
-                    RNS.log("Online firmware version check was disabled, but no firmware version specified for install.")
-                    RNS.log("use the --fw-version option to manually specify a version.")
-                    exit(98)
+                import shutil
+                file = open(UPD_DIR+"/"+fw_filename+".version.latest", "rb")
+                release_info = file.read().decode("utf-8").strip()
+                selected_version = release_info.split()[0]
+                if selected_version == "not":
+                    RNS.log("No valid version found for this board, exiting.")
+                    exit(199)
+
+                selected_hash = release_info.split()[1]
+                if not os.path.isdir(UPD_DIR+"/"+selected_version):
+                    os.makedirs(UPD_DIR+"/"+selected_version)
+                shutil.copy(UPD_DIR+"/"+fw_filename+".version.latest", UPD_DIR+"/"+selected_version+"/"+fw_filename+".version")
+                RNS.log("The selected firmware for this board is version "+selected_version)
+
+            else:
+                RNS.log("Online firmware version check was disabled, but no firmware version specified for install.")
+                RNS.log("use the --fw-version option to manually specify a version.")
+                exit(98)
 
             # if custom firmware url, use it
             if fw_url != None:


### PR DESCRIPTION
Also fixed alternate version downloads which were failing with "Could not read locally cached release information."

Note that this area of code could probably use some refactoring to be more straight-forward but I didn't want to make more assumptions than necessary.