### PR TITLE
feat: implement multicast address type definition on AutoInterface configuration

### DIFF
--- a/RNS/Interfaces/AutoInterface.py
+++ b/RNS/Interfaces/AutoInterface.py
@@ -43,6 +43,9 @@ class AutoInterface(Interface):
     SCOPE_ORGANISATION = "8"
     SCOPE_GLOBAL       = "e"
 
+    MULTICAST_PERMANENT_ADDRESS_TYPE = "0"
+    MULTICAST_TEMPORARY_ADDRESS_TYPE = "1"
+
     PEERING_TIMEOUT    = 7.5
 
     ALL_IGNORE_IFS     = ["lo0"]
@@ -74,7 +77,7 @@ class AutoInterface(Interface):
         ifas = self.netinfo.ifaddresses(ifname)
         return ifas
 
-    def __init__(self, owner, name, group_id=None, discovery_scope=None, discovery_port=None, data_port=None, allowed_interfaces=None, ignored_interfaces=None, configured_bitrate=None):
+    def __init__(self, owner, name, group_id=None, discovery_scope=None, discovery_port=None, multicast_address_type=None, data_port=None, allowed_interfaces=None, ignored_interfaces=None, configured_bitrate=None):
         from RNS.vendor.ifaddr import niwrapper
         super().__init__()
         self.netinfo = niwrapper
@@ -128,6 +131,13 @@ class AutoInterface(Interface):
         else:
             self.discovery_port = discovery_port
 
+        if multicast_address_type == None:
+            self.multicast_address_type = AutoInterface.MULTICAST_TEMPORARY_ADDRESS_TYPE
+        elif str(multicast_address_type).lower() == "temporary":
+            self.multicast_address_type = AutoInterface.MULTICAST_TEMPORARY_ADDRESS_TYPE
+        elif str(multicast_address_type).lower() == "permanent":
+            self.multicast_address_type = AutoInterface.MULTICAST_PERMANENT_ADDRESS_TYPE
+
         if data_port == None:
             self.data_port = AutoInterface.DEFAULT_DATA_PORT
         else:
@@ -156,7 +166,7 @@ class AutoInterface(Interface):
         gt += ":"+"{:02x}".format(g[9]+(g[8]<<8))
         gt += ":"+"{:02x}".format(g[11]+(g[10]<<8))
         gt += ":"+"{:02x}".format(g[13]+(g[12]<<8))
-        self.mcast_discovery_address = "ff1"+self.discovery_scope+":"+gt
+        self.mcast_discovery_address = "ff"+self.multicast_address_type+self.discovery_scope+":"+gt
 
         suitable_interfaces = 0
         for ifname in self.list_interfaces():

--- a/RNS/Reticulum.py
+++ b/RNS/Reticulum.py
@@ -540,6 +540,7 @@ class Reticulum:
                                         group_id        = c["group_id"] if "group_id" in c else None
                                         discovery_scope = c["discovery_scope"] if "discovery_scope" in c else None
                                         discovery_port  = int(c["discovery_port"]) if "discovery_port" in c else None
+                                        multicast_address_type = c["multicast_address_type"] if "multicast_address_type" in c else None
                                         data_port  = int(c["data_port"]) if "data_port" in c else None
                                         allowed_interfaces = c.as_list("devices") if "devices" in c else None
                                         ignored_interfaces = c.as_list("ignored_devices") if "ignored_devices" in c else None
@@ -550,6 +551,7 @@ class Reticulum:
                                             group_id,
                                             discovery_scope,
                                             discovery_port,
+                                            multicast_address_type,
                                             data_port,
                                             allowed_interfaces,
                                             ignored_interfaces

--- a/docs/manual/_sources/interfaces.rst.txt
+++ b/docs/manual/_sources/interfaces.rst.txt
@@ -47,6 +47,12 @@ system, which should be enabled by default in almost all OSes.
 
     group_id = reticulum
 
+    # You can also choose the multicast address type:
+    # temporary (default, Temporary Multicast Address)
+    # or permanent (Permanent Multicast Address)
+
+    multicast_address_type = permanent
+
     # You can also select specifically which
     # kernel networking devices to use.
 

--- a/docs/source/interfaces.rst
+++ b/docs/source/interfaces.rst
@@ -47,6 +47,12 @@ system, which should be enabled by default in almost all OSes.
 
     group_id = reticulum
 
+    # You can also choose the multicast address type:
+    # temporary (default, Temporary Multicast Address)
+    # or permanent (Permanent Multicast Address)
+
+    multicast_address_type = permanent
+
     # You can also select specifically which
     # kernel networking devices to use.
 


### PR DESCRIPTION
**Description**
This implementation allows defining the type of IPv6 multicast address in the AutoInterface configuration.

**Problem**
It has been observed that the WiFi mesh device TP-Link Deco M5 (AC1300 model), doesn't allow IPv6 multicast packet traffic of temporary address types (ff12::/16).

**Tests**
The various tests conducted indicate that, when changing the IPv6 packet type to "permanent", Permanent Multicast Address, ff02::/16, the WiFi AP successfully retransmits the packet. Tests were carried out with different operating systems and some spare Wifi APs from different brands.

**Solution**
Allow defining the type of address in the configuration file between "temporary", default, ff12::/16, and "permanent", ff02::/16.

**Thoughts**
Maybe the TP-Link Deco M5 device has blocked temporary type addresses for security reasons? Who knows...