### PR TITLE
Add product and model, plus support for Heltec V3 serial only setup to rnodeconf.

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -157,6 +157,10 @@ class ROM():
     MODEL_C4       = 0xC4
     MODEL_C9       = 0xC9
 
+    PRODUCT_H32_V3 = 0xC1
+    MODEL_C5       = 0xC5
+    MODEL_CA       = 0xCA
+
     PRODUCT_TBEAM  = 0xE0
     MODEL_E4       = 0xE4
     MODEL_E9       = 0xE9
@@ -203,6 +207,7 @@ products = {
     ROM.PRODUCT_T32_20: "LilyGO LoRa32 v2.0",
     ROM.PRODUCT_T32_21: "LilyGO LoRa32 v2.1",
     ROM.PRODUCT_H32_V2: "Heltec LoRa32 v2",
+    ROM.PRODUCT_H32_V3: "Heltec LoRa32 v3",
 }
 
 platforms = {
@@ -237,6 +242,8 @@ models = {
     0xBB: [850000000, 950000000, 17, "850 - 950 MHz", "rnode_firmware_lora32v10.zip", "SX1276"],
     0xC4: [420000000, 520000000, 17, "420 - 520 MHz", "rnode_firmware_heltec32v2.zip", "SX1278"],
     0xC9: [850000000, 950000000, 17, "850 - 950 MHz", "rnode_firmware_heltec32v2.zip", "SX1276"],
+    0xC5: [470000000, 510000000, 21, "470 - 510 MHz", "rnode_firmware_heltec32v3.zip", "SX1262"],
+    0xCA: [863000000, 928000000, 21, "863 - 928 MHz", "rnode_firmware_heltec32v3.zip", "SX1262"],
     0xE4: [420000000, 520000000, 17, "420 - 520 MHz", "rnode_firmware_tbeam.zip", "SX1278"],
     0xE9: [850000000, 950000000, 17, "850 - 950 MHz", "rnode_firmware_tbeam.zip", "SX1276"],
     0xE3: [420000000, 520000000, 22, "420 - 520 MHz", "rnode_firmware_tbeam_sx1262.zip", "SX1268"],
@@ -1553,6 +1560,7 @@ def main():
             print("[6] LilyGO T-Beam")
             print("[7] Heltec LoRa32 v2")
             print("[8] LilyGO LoRa T3S3")
+            print("[9] Heltec LoRa32 v3")
             print("       .")
             print("      / \\   Select one of these options if you want to easily turn")
             print("       |    a supported development board into an RNode.")
@@ -1564,7 +1572,7 @@ def main():
             try:
                 c_dev = int(input())
                 c_mod = False
-                if c_dev < 1 or c_dev > 8:
+                if c_dev < 1 or c_dev > 9:
                     raise ValueError()
                 elif c_dev == 1:
                     selected_product = ROM.PRODUCT_RNODE
@@ -1673,6 +1681,22 @@ def main():
                     print("                     LilyGO LoRa32 T3S3 RNode Installer")
                     print("")
                     print("Important! Using RNode firmware on T3S3 devices should currently be")
+                    print("considered experimental. It is not intended for production or critical use.")
+                    print("")
+                    print("Please note that Bluetooth is currently not implemented on this board.")
+                    print("")
+                    print("The currently supplied firmware is provided AS-IS as a courtesey to those")
+                    print("who would like to experiment with it. Hit enter to continue.")
+                    print("---------------------------------------------------------------------------")
+                    input()
+                elif c_dev == 9:
+                    selected_product = ROM.PRODUCT_H32_V3
+                    clear()
+                    print("")
+                    print("---------------------------------------------------------------------------")
+                    print("                     Heltec LoRa32 v3.0 RNode Installer")
+                    print("")
+                    print("Important! Using RNode firmware on Heltec devices should currently be")
                     print("considered experimental. It is not intended for production or critical use.")
                     print("")
                     print("Please note that Bluetooth is currently not implemented on this board.")
@@ -1923,6 +1947,28 @@ def main():
                         selected_platform = ROM.PLATFORM_ESP32
                     elif c_model > 1:
                         selected_model = ROM.MODEL_C9
+                        selected_platform = ROM.PLATFORM_ESP32
+                except Exception as e:
+                    print("That band does not exist, exiting now.")
+                    exit()
+
+            elif selected_product == ROM.PRODUCT_H32_V3:
+                selected_mcu = ROM.MCU_ESP32
+                print("\nWhat band is this Heltec LoRa32 V3 for?\n")
+                print("[1] 433 MHz")
+                print("[2] 868 MHz")
+                print("[3] 915 MHz")
+                print("[4] 923 MHz")
+                print("\n? ", end="")
+                try:
+                    c_model = int(input())
+                    if c_model < 1 or c_model > 4:
+                        raise ValueError()
+                    elif c_model == 1:
+                        selected_model = ROM.MODEL_C5
+                        selected_platform = ROM.PLATFORM_ESP32
+                    elif c_model > 1:
+                        selected_model = ROM.MODEL_CA
                         selected_platform = ROM.PLATFORM_ESP32
                 except Exception as e:
                     print("That band does not exist, exiting now.")


### PR DESCRIPTION
Base support for Heltec V3 board as serial only.