### PR TITLE
optionally load identity file from file in Echo and Link examples

### DIFF
--- a/Examples/Echo.py
+++ b/Examples/Echo.py
@@ -38,7 +38,7 @@ def server(configpath):
         server_identity = RNS.Identity.from_file(ifilepath)
         RNS.log("loaded identity from file: "+ifilepath, RNS.LOG_VERBOSE)
     else:
-        # Randomly create a new identity for our link examples
+        # Randomly create a new identity for our echo example
         server_identity = RNS.Identity()
         RNS.log("created new identity", RNS.LOG_VERBOSE)
 

--- a/Examples/Echo.py
+++ b/Examples/Echo.py
@@ -5,6 +5,7 @@
 # of the packet.                                         #
 ##########################################################
 
+import os
 import argparse
 import RNS
 
@@ -27,8 +28,19 @@ def server(configpath):
     # We must first initialise Reticulum
     reticulum = RNS.Reticulum(configpath)
     
-    # Randomly create a new identity for our echo server
-    server_identity = RNS.Identity()
+    # Load identity from file if it exist or randomley create
+    if configpath:
+        ifilepath = "%s/storage/identitiesy/%s" % (configpath,APP_NAME)
+    else:
+        ifilepath = "%s/storage/identities/%s" % (RNS.Reticulum.configdir,APP_NAME)
+    if os.path.exists(ifilepath):
+        # Load identity from file
+        server_identity = RNS.Identity.from_file(ifilepath)
+        RNS.log("loaded identity from file: "+ifilepath, RNS.LOG_VERBOSE)
+    else:
+        # Randomly create a new identity for our link examples
+        server_identity = RNS.Identity()
+        RNS.log("created new identity", RNS.LOG_VERBOSE)
 
     # We create a destination that clients can query. We want
     # to be able to verify echo replies to our clients, so we

--- a/Examples/Echo.py
+++ b/Examples/Echo.py
@@ -341,4 +341,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("")
         exit()
-

--- a/Examples/Echo.py
+++ b/Examples/Echo.py
@@ -340,4 +340,3 @@ if __name__ == "__main__":
                 client(args.destination, configarg, timeout=timeoutarg)
     except KeyboardInterrupt:
         print("")
-        exit()

--- a/Examples/Echo.py
+++ b/Examples/Echo.py
@@ -340,3 +340,5 @@ if __name__ == "__main__":
                 client(args.destination, configarg, timeout=timeoutarg)
     except KeyboardInterrupt:
         print("")
+        exit()
+

--- a/Examples/Link.py
+++ b/Examples/Link.py
@@ -301,4 +301,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("")
         exit()
-

--- a/Examples/Link.py
+++ b/Examples/Link.py
@@ -28,8 +28,20 @@ def server(configpath):
     # We must first initialise Reticulum
     reticulum = RNS.Reticulum(configpath)
     
-    # Randomly create a new identity for our link example
-    server_identity = RNS.Identity()
+    # Load identity from file if it exist or randomley create
+    if configpath:
+        ifilepath = "%s/storage/identitiesy/%s" % (configpath,APP_NAME)
+    else:
+        ifilepath = "%s/storage/identities/%s" % (RNS.Reticulum.configdir,APP_NAME)
+    RNS.log("ifilepath: %s" % ifilepath)
+    if os.path.exists(ifilepath):
+        # Load identity from file
+        server_identity = RNS.Identity.from_file(ifilepath)
+        RNS.log("loaded identity from file: "+ifilepath, RNS.LOG_VERBOSE)
+    else:
+        # Randomly create a new identity for our link examples
+        server_identity = RNS.Identity()
+        RNS.log("created new identity", RNS.LOG_VERBOSE)
 
     # We create a destination that clients can connect to. We
     # want clients to create links to this destination, so we

--- a/Examples/Link.py
+++ b/Examples/Link.py
@@ -300,3 +300,5 @@ if __name__ == "__main__":
 
     except KeyboardInterrupt:
         print("")
+        exit()
+

--- a/Examples/Link.py
+++ b/Examples/Link.py
@@ -300,4 +300,3 @@ if __name__ == "__main__":
 
     except KeyboardInterrupt:
         print("")
-        exit()

--- a/Examples/Link.py
+++ b/Examples/Link.py
@@ -39,7 +39,7 @@ def server(configpath):
         server_identity = RNS.Identity.from_file(ifilepath)
         RNS.log("loaded identity from file: "+ifilepath, RNS.LOG_VERBOSE)
     else:
-        # Randomly create a new identity for our link examples
+        # Randomly create a new identity for our link example
         server_identity = RNS.Identity()
         RNS.log("created new identity", RNS.LOG_VERBOSE)
 


### PR DESCRIPTION
Surface the transparent core option to load the server identity from file in addition to creating it dynamically.

Why in the example:

1. Show the option without changing the default behavior. To make use of it, simply create/drop-in an identity file into the "storage/identities" config sub directory.
2. Saves cut-n-paste eg. if the example is used often.

This feature is transparent and optional.

Note: I'm working on getting the Java Reticulum implementation up to scratch and not having to cut-n-paste on every launch comes in handy. I've built this into the Java equivalent of the Echo and Link Examples as well.