### PR TITLE
Windows DTR timing fix

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -1164,15 +1164,15 @@ def rnode_open_serial(port):
     
 def graceful_exit(C=0):
     if RNS.vendor.platformutils.is_windows():
-        RNS.log("Windows detected; delaying DTR")# ,RNS.LOG_VERBOSE
+        RNS.log("Windows detected; delaying DTR",RNS.LOG_VERBOSE) 
         if rnode:
-            RNS.log("Sending \"Leave\" to Rnode")
+            RNS.log("Sending \"Leave\" to Rnode",RNS.LOG_VERBOSE)
             rnode.leave() # Leave has wait built in
         elif rnode_serial:
-            RNS.log("Closing raw serial")
+            RNS.log("Closing raw serial",RNS.LOG_VERBOSE)
             sleep(1) # Wait for MCU to complete operation before DTR goes false
             rnode_serial.close()
-    RNS.log("Exiting: Code "+str(C))
+    RNS.log("Exiting: Code "+str(C),RNS.LOG_INFO)
     exit(C)
 
 


### PR DESCRIPTION
As noted in #498 at least some drivers or versions of Windows set DTR to low when the COM port disconnects. This commit adds a delay to the disconnect to give the MCU time to write the configuration and shut down gracefully. It accomplishes this in two ways:

First, a one second delay is added to the `RNode.leave` function. This appears to be all that is actually needed.

Second, for a failover, all instances of `exit()` have been replaced with `graceful_exit()`. In addition, the fall-through at the end of `main()` explicitly calls `graceful_exit`.

This function defaults to code 0, but accepts and passes through any integer to `exit()`. It calls additional logic only on Windows systems, calling `leave` if the RNode object still exists, and closes `rnode_serial` if it's still open. Note: I checked all I could, even dummying out `disconnect()` entirely, but couldn't seem to get it to trigger the checks or error out. If there's a better way to check, please let me know.

In any case, tested on Windows 10 Pro, where the RNode functioned as expected (but this does not fix the halting, only the RNodeConf issues) and Debian, where functionality was unchanged (except the logging of the exit code if the proper levels are set).