### PR TITLE
Implement AutoInterface support on Windows

### DIFF
--- a/RNS/Reticulum.py
+++ b/RNS/Reticulum.py
@@ -536,46 +536,40 @@ class Reticulum:
 
                             if (("interface_enabled" in c) and c.as_bool("interface_enabled") == True) or (("enabled" in c) and c.as_bool("enabled") == True):
                                 if c["type"] == "AutoInterface":
-                                    if not RNS.vendor.platformutils.is_windows():
-                                        group_id        = c["group_id"] if "group_id" in c else None
-                                        discovery_scope = c["discovery_scope"] if "discovery_scope" in c else None
-                                        discovery_port  = int(c["discovery_port"]) if "discovery_port" in c else None
-                                        multicast_address_type = c["multicast_address_type"] if "multicast_address_type" in c else None
-                                        data_port  = int(c["data_port"]) if "data_port" in c else None
-                                        allowed_interfaces = c.as_list("devices") if "devices" in c else None
-                                        ignored_interfaces = c.as_list("ignored_devices") if "ignored_devices" in c else None
+                                    group_id        = c["group_id"] if "group_id" in c else None
+                                    discovery_scope = c["discovery_scope"] if "discovery_scope" in c else None
+                                    discovery_port  = int(c["discovery_port"]) if "discovery_port" in c else None
+                                    multicast_address_type = c["multicast_address_type"] if "multicast_address_type" in c else None
+                                    data_port  = int(c["data_port"]) if "data_port" in c else None
+                                    allowed_interfaces = c.as_list("devices") if "devices" in c else None
+                                    ignored_interfaces = c.as_list("ignored_devices") if "ignored_devices" in c else None
 
-                                        interface = AutoInterface.AutoInterface(
-                                            RNS.Transport,
-                                            name,
-                                            group_id,
-                                            discovery_scope,
-                                            discovery_port,
-                                            multicast_address_type,
-                                            data_port,
-                                            allowed_interfaces,
-                                            ignored_interfaces
-                                        )
+                                    interface = AutoInterface.AutoInterface(
+                                        RNS.Transport,
+                                        name,
+                                        group_id,
+                                        discovery_scope,
+                                        discovery_port,
+                                        multicast_address_type,
+                                        data_port,
+                                        allowed_interfaces,
+                                        ignored_interfaces
+                                    )
 
-                                        if "outgoing" in c and c.as_bool("outgoing") == False:
-                                            interface.OUT = False
-                                        else:
-                                            interface.OUT = True
-
-                                        interface.mode = interface_mode
-
-                                        interface.announce_cap = announce_cap
-                                        if configured_bitrate:
-                                            interface.bitrate = configured_bitrate
-                                        if ifac_size != None:
-                                            interface.ifac_size = ifac_size
-                                        else:
-                                            interface.ifac_size = 16
-
+                                    if "outgoing" in c and c.as_bool("outgoing") == False:
+                                        interface.OUT = False
                                     else:
-                                        RNS.log("AutoInterface is not currently supported on Windows, disabling interface.", RNS.LOG_ERROR);
-                                        RNS.log("Please remove this AutoInterface instance from your configuration file.", RNS.LOG_ERROR);
-                                        RNS.log("You will have to manually configure other interfaces for connectivity.", RNS.LOG_ERROR);
+                                        interface.OUT = True
+
+                                    interface.mode = interface_mode
+
+                                    interface.announce_cap = announce_cap
+                                    if configured_bitrate:
+                                        interface.bitrate = configured_bitrate
+                                    if ifac_size != None:
+                                        interface.ifac_size = ifac_size
+                                    else:
+                                        interface.ifac_size = 16
 
                                 if c["type"] == "UDPInterface":
                                     device       = c["device"] if "device" in c else None

--- a/RNS/vendor/ifaddr/niwrapper.py
+++ b/RNS/vendor/ifaddr/niwrapper.py
@@ -11,6 +11,13 @@ def interfaces() -> List[str]:
     adapters = RNS.vendor.ifaddr.get_adapters(include_unconfigured=True)
     return [a.name for a in adapters]
 
+def interface_names_to_indexes() -> dict:
+    adapters = RNS.vendor.ifaddr.get_adapters(include_unconfigured=True)
+    results = {}
+    for adapter in adapters:
+        results[adapter.name] = adapter.index
+    return results
+
 def ifaddresses(ifname) -> dict:
     adapters = RNS.vendor.ifaddr.get_adapters(include_unconfigured=True)
     ifa = {}


### PR DESCRIPTION
This PR adds support for using the `AutoInterface` on Windows machines.

I have tested the following setups, and they appear to be working!

**Setup 1**

- MacBook Pro connected to Ethernet with `AutoInterface`
- Windows 10 PC connected to Ethernet with `AutoInterface`
- MacBook can exchange announces, messages and files with Windows 10 (tested Sideband and WebChat)
- `rnpath` to MacBook from Windows PC shows roundtrip time of ~33ms with 1 hop
- `rnpath` to EchoBot from Windows PC times out, as there is no path yet

**Setup 2**

- MacBook Pro connected to;
  - Ethernet with `AutoInterface`
  - RNS Testnet Amsterdam via `TCPClientInterface`
- Windows 10 PC connected to Ethernet with `AutoInterface`
- `rnpath` to EchoBot from Windows PC shows a rountrip time of ~893ms with 4 hops
- `rnprobe` to `lxmf.delivery 1dbc2281c4223c7a479de8cd8a988ae4` from Windows PC was also successful

**Setup 3**

- Windows 10 PC connected to Ethernet with `AutoInterface`
- Samsung A21s connected to WiFi with `AutoInterface`
- iPhone 11 Pro connected to WiFi with `AutoInterface`
- Samsung and iPhone are both able to send and receive messages from Windows 10 PC in Sideband

> Note: The Ethernet and WiFi devices in this setup are connected to the same physical Router/Switch.

**Notes**

I have tested running this commit on the Windows PC as well as the MacBook and the changes don't appear to have broken anything, however I have not added this commit to Sideband or Nomadnet to see if they still behave the same way. I would assume so...

The Windows specific changes to the `socket.bind(...)` call are put behind an os check, but I did make a few other changes to how the interface names are converted to index numbers.

I found on Windows, it would return a UUID as the interface name, but when this was passed to `socket.if_nametoindex(...)` it would complain about the interface not being found. I could pass in `ethernet_0` and it would find it. I opted to use the netinfo wrapper to get the index instead. Unsure if this is the best for performance, however this PR is intended to provide a working solution that we can improve upon.

When passing the multicast address as the host to `discovery_socket.bind`, or when passing the interface index as the 4th parameter, Windows throws `[WinError 10049] The requested address is not valid in its context`.

I was able to get around this by not passing a host at all, and omitting the interface index. This too, is behind an os check to avoid changing the functionality on other platforms that already work as intended.

This is my first time playing around with IPv6/Socket Multicasting, so I have no idea of any unintended consequences of not passing in the multicast address and interface index to the socket binding.

**Original Discussion**

Here's a [link to the Matrix discussion](https://matrix.to/#/!TRaVWNnQhAbvuiSnEK:matrix.org/$N3iiK6Jf5SwIO5h6lwCocTlvvYG3wrMyeHxRWCOJgRY?via=matrix.org&via=tchncs.de&via=envs.net) where @faragher confirms this is working on Windows 10 Pro as well.