### PR TITLE
Fix for macos failing to set firmware hash on NRF52

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -3440,6 +3440,10 @@ def main():
                                 time.sleep(6.5)
 
                             elif rnode.platform == ROM.PLATFORM_NRF52:
+                                # Wait a few seconds before hard resetting.
+                                # Otherwise, macOS fails to set firmware hash on NRF52
+                                time.sleep(5)
+
                                 rnode.hard_reset()
                                 # The hard reset on this platform is different
                                 # to that of the ESP32 platform, it causes

--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -3442,7 +3442,8 @@ def main():
                             elif rnode.platform == ROM.PLATFORM_NRF52:
                                 # Wait a few seconds before hard resetting.
                                 # Otherwise, macOS fails to set firmware hash on NRF52
-                                time.sleep(5)
+                                if RNS.vendor.platformutils.is_darwin():
+                                    time.sleep(5)
 
                                 rnode.hard_reset()
                                 # The hard reset on this platform is different


### PR DESCRIPTION
As the title states, this makes it possible to flash RAK4631 boards successfully on Mac.