### PR TITLE
Fix for broken `--rom` manual device provisioning

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -3310,6 +3310,8 @@ def main():
                             if len(args.model) == 2:
                                 model = ord(bytes.fromhex(args.model))
 
+                        # Initialize selected_model from specified model
+                        selected_model = model
 
                     if args.hwrev != None and (args.hwrev > 0 and args.hwrev < 256):
                         hwrev = chr(args.hwrev)


### PR DESCRIPTION
Initializes `selected_model` with the value of model specified on the command line.