### PR TITLE
fixed small typo : egraceful_xit()

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -3204,7 +3204,7 @@ def main():
 
                 else:
                     RNS.log("EEPROM is invalid, no further information available")
-                    egraceful_xit()
+                    graceful_exit()
 
             if args.rom:
                 if rnode.provisioned and not args.autoinstall:


### PR DESCRIPTION
typo in Reticulum/RNS/Utilities/rnodeconf.py (egraceful_xit())
that cause a crash if we run rnodeconf -i on an unprovisioned node

(for context I'm trying to make a rnode using an ESP32-C3 and a XL1278-SMT.
I figured out how to compile new firmware image using the arduino CLI and might have a few thing to write in a separate discussion regarding the procedure to create new node. there are a few small issue to wrinkle but I need to first get a hang of the whole codebase.

currently i'm stuck while trying to bootstrap the eeprom but I fail to understand how it works and what is stored on that eeprom. Still trying to find a revelant discussion about that and might create a new one if that fail.

anyway thanks for this amazing tool.
I'm having fun trying to make my little rnode :)

(next time I will just buy the recommanded hardware instead of trying to save up a few $$$ and spend the time on air instead of making a new firmware :') 
