### PR TITLE
Support IPv6 for outbound TCP interface (TCPClientInterface)

### DIFF
--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -200,7 +200,7 @@ class TCPClientInterface(Interface):
             if initial:
                 RNS.log("Establishing TCP connection for "+str(self)+"...", RNS.LOG_DEBUG)
 
-            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket = socket.socket(socket.AF_INET|socket.AF_INET6, socket.SOCK_STREAM)
             self.socket.settimeout(TCPClientInterface.INITIAL_CONNECT_TIMEOUT)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket.connect((self.target_ip, self.target_port))


### PR DESCRIPTION
As per commit.

(Single line commit: BIG BRAIN :brain: )


---

Still haven't yet figured out the bind-side of things for the equivalent `TCPServerInterface` because I see the mention of class, rather than instance, variables and that seems sus to tamper with (I don't know Python, so I'd rather not)