### PR TITLE
Fix interface values not being set on RNodeSubInterface instances

### DIFF
--- a/RNS/Interfaces/RNodeMultiInterface.py
+++ b/RNS/Interfaces/RNodeMultiInterface.py
@@ -249,6 +249,7 @@ class RNodeMultiInterface(Interface):
         if (not self.validcfg):
             raise ValueError("The configuration for "+str(self)+" contains errors, interface is offline")
 
+    def start(self):
         try:
             self.open_port()
 
@@ -323,8 +324,8 @@ class RNodeMultiInterface(Interface):
                         lt_alock=subint[9]
                 )
 
-                interface.OUT = self.OUT
-                interface.IN  = self.IN
+                interface.OUT = subint[10]
+                interface.IN  = True
                 
                 interface.announce_rate_target = self.announce_rate_target
                 interface.mode = self.mode
@@ -1005,6 +1006,11 @@ class RNodeSubInterface(Interface):
         self.interface_ready = False
         self.parent_interface = parent_interface
         self.announce_rate_target = None
+
+        self.mode = None
+        self.announce_cap = None
+        self.bitrate = None
+        self.ifac_size = None
 
         # add this interface to the subinterfaces array
         self.parent_interface.subinterfaces[index] = self

--- a/RNS/Reticulum.py
+++ b/RNS/Reticulum.py
@@ -971,7 +971,7 @@ class Reticulum:
                                                 enabled_count += 1
 
                                     # Create an array with a row for each subinterface
-                                    subint_config = [[0 for x in range(10)] for y in range(enabled_count)]
+                                    subint_config = [[0 for x in range(11)] for y in range(enabled_count)]
                                     subint_index = 0
 
                                     for subinterface in c:
@@ -1000,6 +1000,11 @@ class Reticulum:
                                                 subint_config[subint_index][8] = st_alock
                                                 lt_alock = float(subinterface_config["airtime_limit_long"]) if "airtime_limit_long" in subinterface_config else None
                                                 subint_config[subint_index][9] = lt_alock
+
+                                                if "outgoing" in subinterface_config and subinterface_config.as_bool("outgoing") == False:
+                                                    subint_config[subint_index][10] = False
+                                                else:
+                                                    subint_config[subint_index][10] = True
                                                 subint_index += 1
 
                                     # if no subinterfaces are defined
@@ -1025,10 +1030,8 @@ class Reticulum:
                                         id_callsign = id_callsign
                                     )
 
-                                    if "outgoing" in c and c.as_bool("outgoing") == False:
-                                        interface.OUT = False
-                                    else:
-                                        interface.OUT = True
+                                    interface.IN = False
+                                    interface.OUT = False
 
                                     interface.mode = interface_mode
 
@@ -1078,6 +1081,9 @@ class Reticulum:
                                         interface.ifac_signature = interface.ifac_identity.sign(RNS.Identity.full_hash(interface.ifac_key))
 
                                     RNS.Transport.interfaces.append(interface)
+
+                                    if isinstance(interface, RNS.Interfaces.RNodeMultiInterface.RNodeMultiInterface):
+                                        interface.start()
 
                             else:
                                 RNS.log("Skipping disabled interface \""+name+"\"", RNS.LOG_DEBUG)


### PR DESCRIPTION
This one's on me. So, when I designed RNodeMultiInterface, it didn't occur to me that the interface values being set in `Reticulum.py` would not actually be set until after the class was initialised. And since these values are passed on to the `RNodeSubInterface` before they're actually initialised, this created a problem. The actual values will never be set in the subinterface (which is the one actually processing packets).

The way this manifested as a bug was in the fact that `self.OUT` would be set to false on all RNodeSubInterface instances until the interface was destroyed and recreated (i.e. through pulling the connection to the RNode). So, every first connection when the RNS daemon started would result in it not being able to transmit on any of the RNodeSubInterface instances. This would likely have other implications if not fixed as well, such as affecting IFAC or other things which are set on the interface after it is started.

I don't know how you'll feel about the `.start()` call I made in this PR Mark. It would be entirely possible to create a thread to run in a second or so in the future after the `__init__()` is called for RNodeMultiInterface in the actual class. That could be done, but I do have reservations about it potentially creating race conditions. At least in this current implementation, it should guarantee this issue does not resurface, but may not be to your liking as of current.