### PR TITLE
Fix RNodeMultiInterface interface framing

### DIFF
--- a/RNS/Interfaces/RNodeMultiInterface.py
+++ b/RNS/Interfaces/RNodeMultiInterface.py
@@ -70,7 +70,7 @@ class KISS():
     CMD_INT1_DATA   = 0x10
     CMD_INT2_DATA   = 0x20
     CMD_INT3_DATA   = 0x70
-    CMD_INT4_DATA   = 0x80
+    CMD_INT4_DATA   = 0x75
     CMD_INT5_DATA   = 0x90
     CMD_INT6_DATA   = 0xA0
     CMD_INT7_DATA   = 0xB0
@@ -82,8 +82,8 @@ class KISS():
     CMD_SEL_INT0    = 0x1E
     CMD_SEL_INT1    = 0x1F
     CMD_SEL_INT2    = 0x2F
-    CMD_SEL_INT3    = 0x7F
-    CMD_SEL_INT4    = 0x8F
+    CMD_SEL_INT3    = 0x74
+    CMD_SEL_INT4    = 0x7F
     CMD_SEL_INT5    = 0x9F
     CMD_SEL_INT6    = 0xAF
     CMD_SEL_INT7    = 0xBF

--- a/RNS/Interfaces/RNodeMultiInterface.py
+++ b/RNS/Interfaces/RNodeMultiInterface.py
@@ -166,7 +166,7 @@ class RNodeMultiInterface(Interface):
     CALLSIGN_MAX_LEN    = 32
 
     REQUIRED_FW_VER_MAJ = 1
-    REQUIRED_FW_VER_MIN = 73
+    REQUIRED_FW_VER_MIN = 74
 
     RECONNECT_WAIT = 5
 


### PR DESCRIPTION
I forgot to check if CMD_INT4_DATA conflicted with any other bytes assigned to frames. It conflicts with CMD_ERROR. I've made the necessary changes to fix this issue.

The branch `frame-fix` will be merged for version `1.74` of the CE firmware. This should ideally be merged just after that point to prevent causing issues of requiring a non-existent firmware version ;)
