### PR TITLE
Determine AF FAMILY from getaddrinfo BEFORE socket ctor

### DIFF
--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -200,7 +200,9 @@ class TCPClientInterface(Interface):
             if initial:
                 RNS.log("Establishing TCP connection for "+str(self)+"...", RNS.LOG_DEBUG)
 
-            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            addrInfo=socket.getaddrinfo(self.target_ip, self.target_port)
+            addrFam=addrInfo[0]
+            self.socket = socket.socket(addrFam, socket.SOCK_STREAM)
             self.socket.settimeout(TCPClientInterface.INITIAL_CONNECT_TIMEOUT)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket.connect((self.target_ip, self.target_port))


### PR DESCRIPTION
Before we call the `socket.socket(...)` constructor function, let us first provide `self.target_ip` and `self.target_port` to `socket.getaddrinfo(...)` (static function) and then get the AF family from it. Then we pass this into the ctor