### PR TITLE
Allow binding to IPv6 (if present)

### DIFF
--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -200,9 +200,7 @@ class TCPClientInterface(Interface):
             if initial:
                 RNS.log("Establishing TCP connection for "+str(self)+"...", RNS.LOG_DEBUG)
 
-            addrInfo=socket.getaddrinfo(self.target_ip, self.target_port)
-            addrFam=addrInfo[0]
-            self.socket = socket.socket(addrFam, socket.SOCK_STREAM)
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(TCPClientInterface.INITIAL_CONNECT_TIMEOUT)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket.connect((self.target_ip, self.target_port))

--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -412,11 +412,6 @@ class TCPServerInterface(Interface):
     def get_address_for_if(name):
         import RNS.vendor.ifaddr.niwrapper as netinfo
         ifaddr = netinfo.ifaddresses(name)
-
-        # IPv6 preference (if present)
-        if(netinfo.AF_INET6 in ifaddr):
-            return ifaddr[netinfo.AF_INET6][0]["addr"]
-        
         return ifaddr[netinfo.AF_INET][0]["addr"]
 
     @staticmethod

--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -412,6 +412,11 @@ class TCPServerInterface(Interface):
     def get_address_for_if(name):
         import RNS.vendor.ifaddr.niwrapper as netinfo
         ifaddr = netinfo.ifaddresses(name)
+
+        # IPv6 preference (if present)
+        if(netinfo.AF_INET6 in ifaddr):
+            return ifaddr[netinfo.AF_INET6][0]["addr"]
+        
         return ifaddr[netinfo.AF_INET][0]["addr"]
 
     @staticmethod

--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -200,7 +200,9 @@ class TCPClientInterface(Interface):
             if initial:
                 RNS.log("Establishing TCP connection for "+str(self)+"...", RNS.LOG_DEBUG)
 
-            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            addrInfo=socket.getaddrinfo(self.target_ip, self.target_port)
+            addrFam=addrInfo[0]
+            self.socket = socket.socket(addrFam, socket.SOCK_STREAM)
             self.socket.settimeout(TCPClientInterface.INITIAL_CONNECT_TIMEOUT)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket.connect((self.target_ip, self.target_port))


### PR DESCRIPTION
If an interface has an IPv6 address record associated with it then, and only then, prefer that.

Otherwise AF_INET is used (Ipv4 address)

- [x] `get_address_for_if(string)` done
- [ ] `get_broadcast_for_if(string)`