### PR TITLE
fix:TCPInterface: Try connect to both IPv4 & IPv6

### DIFF
--- a/RNS/Interfaces/TCPInterface.py
+++ b/RNS/Interfaces/TCPInterface.py
@@ -220,14 +220,11 @@ class TCPClientInterface(Interface):
             if initial:
                 RNS.log("Establishing TCP connection for "+str(self)+"...", RNS.LOG_DEBUG)
 
-            address_info = socket.getaddrinfo(self.target_ip, self.target_port, proto=socket.IPPROTO_TCP)[0]
-            address_family = address_info[0]
-            target_address = address_info[4]
-
-            self.socket = socket.socket(address_family, socket.SOCK_STREAM)
-            self.socket.settimeout(TCPClientInterface.INITIAL_CONNECT_TIMEOUT)
+            self.socket = socket.create_connection(
+                (self.target_ip, self.target_port),
+                timeout=TCPClientInterface.INITIAL_CONNECT_TIMEOUT
+                )
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self.socket.connect(target_address)
             self.socket.settimeout(None)
             self.online  = True
 


### PR DESCRIPTION
I noticed last night that RNS couldn't connect to the Chaosnet node (rns.c3.jitter.eu) IPv6 as it was firewalled and refusing connections, but RNS never tried the IPv4 address. 

This change uses the socket.create_connection function to run the Happy Eyeballs procedure of resolving all addresses and trying to connect to them until 1 succeeds.

-Kevin
