### PR TITLE
Flush stdout when logging to appear immediately in syslog.

### DIFF
--- a/RNS/__init__.py
+++ b/RNS/__init__.py
@@ -128,6 +128,7 @@ def log(msg, level=3, _override_destination = False, pt=False):
         with logging_lock:
             if (logdest == LOG_STDOUT or _always_override_destination or _override_destination):
                 print(logstring)
+                sys.stdout.flush()
 
             elif (logdest == LOG_FILE and logfile != None):
                 try:


### PR DESCRIPTION
This fix allows log output to appear immediately in journald, rather than being buffered and appearing much later.