### PR TITLE
Maintain Interface name in Reticulum.get_interface_stats

### DIFF
--- a/RNS/Reticulum.py
+++ b/RNS/Reticulum.py
@@ -1020,7 +1020,8 @@ class Reticulum:
                     else:
                         ifstats["announce_queue"] = None
 
-                ifstats["name"] = str(interface)
+                ifstats["name"] = str(interface.name)
+                ifstats["repr_name"] = str(interface)
                 ifstats["short_name"] = str(interface.name)
                 ifstats["hash"] = interface.get_hash()
                 ifstats["type"] = str(type(interface).__name__)


### PR DESCRIPTION
Keep the Interface.name consistent across the API, since it is the unique ID for the Interface.