### PR TITLE
Fix Link.mtu_bytes

### DIFF
--- a/RNS/Link.py
+++ b/RNS/Link.py
@@ -28,7 +28,6 @@ from time import sleep
 from .vendor import umsgpack as umsgpack
 import threading
 import inspect
-import struct
 import math
 import time
 import RNS
@@ -110,7 +109,7 @@ class Link:
 
     @staticmethod
     def mtu_bytes(mtu):
-        return struct.pack(">I", mtu & 0xFFFFFF)[1:]
+        return mtu.to_bytes(3, byteorder='big', signed=False)
 
     @staticmethod
     def mtu_from_lr_packet(packet):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,18 @@
+# Tests for RNS.Link
+
+import pytest
+
+from RNS.Link import Link
+
+def test_mtu_bytes():
+    data = [
+        (0, bytes([0, 0, 0])),
+        (5, bytes([0, 0, 5])),
+        (256, bytes([0, 1, 0])),
+        (65536, bytes([1, 0, 0])),
+        (16777215, bytes([255, 255, 255])),
+        ]
+    for inp, outp in data:
+        assert Link.mtu_bytes(inp) == outp, f"Error:{inp} packed wrong"
+    pytest.raises(OverflowError, Link.mtu_bytes, -5)  # Out of range
+    pytest.raises(OverflowError, Link.mtu_bytes, 20_000_000)  # Out of range


### PR DESCRIPTION
mtu_bytes() silently reduces the MTU to 1 if the parameter is 1 byte over the allowed max size.

Unlikely to hit this bug, but might be difficult to debug if so.

-Kevin
