### PR TITLE
Modify exit handling to prevent test runner exit

### DIFF
--- a/RNS/Identity.py
+++ b/RNS/Identity.py
@@ -24,7 +24,6 @@ import math
 import os
 import RNS
 import time
-import atexit
 import hashlib
 import threading
 

--- a/RNS/Utilities/rnsd.py
+++ b/RNS/Utilities/rnsd.py
@@ -24,6 +24,7 @@
 
 import RNS
 import argparse
+import signal
 import time
 
 from RNS._version import __version__
@@ -45,9 +46,15 @@ def program_setup(configdir, verbosity = 0, quietness = 0, service = False):
         if RNS.Reticulum.get_instance().shared_instance_interface:
             RNS.Reticulum.get_instance().shared_instance_interface.server.daemon_threads = True
         RNS.log("Started rnsd version {version}".format(version=__version__), RNS.LOG_NOTICE)
+        #signal.signal(signal.SIGINT, reticulum.sigint_handler)
+        signal.signal(signal.SIGTERM, reticulum.sigterm_handler)
 
-    while True:
-        time.sleep(1)
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        reticulum.stop()
+
 
 def main():
     try:
@@ -63,7 +70,7 @@ def main():
 
         if args.exampleconfig:
             print(__example_rns_config__)
-            exit()
+            return
 
         if args.config:
             configarg = args.config

--- a/RNS/__init__.py
+++ b/RNS/__init__.py
@@ -368,7 +368,7 @@ def exit():
         exit_called = True
         print("")
         Reticulum.exit_handler()
-        os._exit(0)
+        #os._exit(0)
 
 class Profiler:
     _ran = False


### PR DESCRIPTION
These changes take another step towards easier testing of RNS:

The TERM signal handler is now set up in rnsd.py as it needs to run on the main thread - the previous location caused errors in test runners.
The INTR signal is now handled by rnsd - the finally clause will shutdown Reticulum.

All the exit methods are now together and use flags to prevent them from being executed multiple times.

The os._exit() call in RNS.exit() is also commented out to prevent RNS from killing the Python interpreter at unexpected times (e.g. during test runs). RNS.exit() seems to be called only from LocalInterface.teardown() and seems to shutdown OK without the os._exit() call in my testing, but I'm not able to test under Android.

-Kevin
