### PR TITLE
add rnodeconf support for SeeedStudio XIAO esp32s3 wio

### DIFF
--- a/RNS/Utilities/rnodeconf.py
+++ b/RNS/Utilities/rnodeconf.py
@@ -199,6 +199,10 @@ class ROM():
     MODEL_C6            = 0xC6 # Heltec Mesh Node T114, 470-510 MHz (HT-n5262-LF)
     MODEL_C7            = 0xC7 # Heltec Mesh Node T114, 863-928 MHz (HT-n5262-HF)
     
+    PRODUCT_XIAO_ESP32S3 = 0xEB
+    BOARD_XIAO_ESP32S3   = 0x3E
+    MODEL_DD             = 0xDD # Xiao ESP32S3 with WIO lora module, 868 MHz
+
     PRODUCT_HMBRW  = 0xF0
     MODEL_FF       = 0xFF
     MODEL_FE       = 0xFE
@@ -261,6 +265,7 @@ products = {
     ROM.PRODUCT_RAK4631: "RAK4631",
     ROM.PRODUCT_OPENCOM_XL: "openCom XL",
     ROM.PRODUCT_HELTEC_T114: "Heltec Mesh Node T114",
+    ROM.PRODUCT_XIAO_ESP32S3: "SeeedStudio XIAO esp32s3 wio",
 }
 
 platforms = {
@@ -317,6 +322,7 @@ models = {
     0x16: [779000000, 928000000, 22, "430 - 510 Mhz", "rnode_firmware_techo.zip", "SX1262"],
     0x17: [779000000, 928000000, 22, "779 - 928 Mhz", "rnode_firmware_techo.zip", "SX1262"],
     0x21: [820000000, 960000000, 22, "820 - 960 MHz", "rnode_firmware_opencom_xl.zip", "SX1262 + SX1280"],
+    0xDD: [850000000, 950000000, 22, "850 - 950 MHz", "rnode_firmware_xiao_esp32s3.zip", "SX1262"],
     0xFE: [100000000, 1100000000, 17, "(Band capabilities unknown)", None, "Unknown"],
     0xFF: [100000000, 1100000000, 14, "(Band capabilities unknown)", None, "Unknown"],
 }
@@ -1720,6 +1726,7 @@ def main():
             print("[12] LilyGO T-Beam Supreme")
             print("[13] LilyGO T-Deck")
             print("[14] Heltec T114")
+            print("[15] SeeedStudio esp32s3 xiao wio")
             print("")
             print("---------------------------------------------------------------------------")
             print("\nEnter the number that matches your device type:\n? ", end="")
@@ -1728,7 +1735,7 @@ def main():
             try:
                 c_dev = int(input())
                 c_mod = False
-                if c_dev < 1 or c_dev > 14:
+                if c_dev < 1 or c_dev > 15:
                     raise ValueError()
                 elif c_dev == 1:
                     selected_product = ROM.PRODUCT_RNODE
@@ -1919,6 +1926,19 @@ def main():
                     print("                      Heltec T114 RNode Installer")
                     print("")
                     print("Important! Using RNode firmware on Heltec T114 devices should currently be")
+                    print("considered experimental. It is not intended for production or critical use.")
+                    print("The currently supplied firmware is provided AS-IS as a courtesey to those")
+                    print("who would like to experiment with it. Hit enter to continue.")
+                    print("---------------------------------------------------------------------------")
+                    input()
+                elif c_dev == 15:
+                    selected_product = ROM.PRODUCT_XIAO_ESP32S3
+                    clear()
+                    print("")
+                    print("---------------------------------------------------------------------------")
+                    print("                 SeeedStudio XIAO esp32s3 wio RNode Installer")
+                    print("")
+                    print("Important! Using RNode firmware on SeeedStudio XIAO/wio devices should currently be")
                     print("considered experimental. It is not intended for production or critical use.")
                     print("The currently supplied firmware is provided AS-IS as a courtesey to those")
                     print("who would like to experiment with it. Hit enter to continue.")
@@ -2268,7 +2288,22 @@ def main():
                 except Exception as e:
                     print("That band does not exist, exiting now.")
                     exit()
-            
+
+            elif selected_product == ROM.PRODUCT_XIAO_ESP32S3:
+                selected_mcu = ROM.MCU_ESP32
+                print("\nWhat band is this XIAO esp32s3 wio module for?\n")
+                print("[1] 868 MHz")
+                try:
+                    c_model = int(input())
+                    if c_model < 1 or c_model > 1:
+                        raise ValueError()
+                    elif c_model == 1:
+                        selected_model = ROM.MODEL_DD
+                        selected_platform = ROM.PLATFORM_ESP32
+                except Exception as e:
+                    print("That band does not exist, exiting now.")
+                    exit()
+
             elif selected_product == ROM.PRODUCT_RAK4631:
                 selected_mcu = ROM.MCU_NRF52
                 print("\nWhat band is this RAK4631 for?\n")
@@ -3059,6 +3094,24 @@ def main():
                             "0x10000", UPD_DIR+"/"+selected_version+"/rnode_firmware_tdeck.bin",
                             "0x210000",UPD_DIR+"/"+selected_version+"/console_image.bin",
                             "0x8000",  UPD_DIR+"/"+selected_version+"/rnode_firmware_tdeck.partitions",
+                        ]
+                    elif fw_filename == "rnode_firmware_xiao_esp32s3.zip":
+                        return [
+                            sys.executable, flasher,
+                            "--chip", "esp32s3",
+                            "--port", args.port,
+                            "--baud", args.baud_flash,
+                            "--before", "default_reset",
+                            "--after", "hard_reset",
+                            "write_flash", "-z",
+                            "--flash_mode", "dio",
+                            "--flash_freq", "80m",
+                            "--flash_size", "8MB",
+                            "0xe000",  UPD_DIR+"/"+selected_version+"/rnode_firmware_xiao_esp32s3.boot_app0",
+                            "0x0",  UPD_DIR+"/"+selected_version+"/rnode_firmware_xiao_esp32s3.bootloader",
+                            "0x10000", UPD_DIR+"/"+selected_version+"/rnode_firmware_xiao_esp32s3.bin",
+                            "0x210000",UPD_DIR+"/"+selected_version+"/console_image.bin",
+                            "0x8000",  UPD_DIR+"/"+selected_version+"/rnode_firmware_xiao_esp32s3.partitions",
                         ]
                     elif fw_filename == "extracted_rnode_firmware.zip":
                         return [


### PR DESCRIPTION
This PR supersceeds and extends PR #733 , it incorporates recent cleanup, uses the correct frequency range for the SX1262, and has the autoinstall section more completely defined.

It assumes the support for the XIAO/WIO board has been incorporated from the CE RNode project : [7342116](https://github.com/liberatedsystems/RNode_Firmware_CE/commit/7342116d91221391376cb7cc4e107d648c32a0d7) & [ea77f3b](https://github.com/liberatedsystems/RNode_Firmware_CE/commit/ea77f3b32e6eae68a9bfd2290d1c6efb62af071d) : and that the firmware from that is available in the releases folder + json index for autoinstall.

Apologies if this is already covered and un-needed. I have been setting up this board for myself, and needed a working rnodeconf for that; so it seemed sensible to offer it here. 

Also note that this a a 8Mb flash board; I raised an [issue](https://github.com/liberatedsystems/RNode_Firmware_CE/issues/68) with the CE project since they use 4Mb in the upload targets of the `Makefile` there.