### PR TITLE
 Add PR Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/🐛-bug-report.md
@@ -12,7 +12,6 @@ Before creating a bug report on this issue tracker, you **must** read the [Contr
 
 - The issue tracker is used by developers of this project. **Do not use it to ask general questions, or for support requests**.
 - Ideas and feature requests can be made on the [Discussions](https://github.com/markqvist/Reticulum/discussions). **Only** feature requests accepted by maintainers and developers are tracked and included on the issue tracker. **Do not post feature requests here**.
-- Do not submit code written using large language models (LLMs) or other generative 'AI' programs (see the [Generative AI Policy](/Contributing.md#generative-ai-policy) for details).
 - After reading the [Contribution Guidelines](https://github.com/markqvist/Reticulum/blob/master/Contributing.md), **delete this section only** (*"Read the Contribution Guidelines"*) from your bug report, **and fill in all the other sections**.
 
 **Describe the Bug**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+### Read the Contribution Guidelines
+Before creating a pull request in this repository, you **must** read the [Contribution Guidelines](https://github.com/markqvist/Reticulum/blob/master/Contributing.md).
+
+- Do not submit code written using large language models (LLMs) or other generative 'AI' programs (see the [Generative AI Policy](/Contributing.md#generative-ai-policy) for details).
+- After reading the [Contribution Guidelines](https://github.com/markqvist/Reticulum/blob/master/Contributing.md), write "I agree to the Contribution Guidelines" at the end of your message then delete this text from your pull request to signify your acceptance.


### PR DESCRIPTION
This adds [a Pull Request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).
You should probably add this to your other repositories as well if you find it acceptable.

This PR also reverts "Add Generative AI Policy reminder to 🐛-bug-report.md" because
1. It would require adding it to all of the other repositories for consistency which is a lot of manual work.
2. It fits better in the PR template anyway.

Hope this is useful. :+1: 

I agree to the Contribution Guidelines