### PR TITLE
Fix exit method to use sys.exit for proper cleanup

### DIFF
--- a/RNS/__init__.py
+++ b/RNS/__init__.py
@@ -382,7 +382,7 @@ def exit(code=0):
     if not exit_called:
         exit_called = True
         Reticulum.exit_handler()
-        os._exit(code)
+        sys.exit(code)
 
 class Profiler:
     _ran = False


### PR DESCRIPTION
## Summary
Changes the `exit` method in `RNS.__init__.py` to use `sys.exit()` instead of `os._exit()` to allow proper cleanup and exception handling.

## Changes
- Replace `os._exit()` with `sys.exit()` in the `exit` method
- Keep `panic` method using `os._exit()` for immediate termination in unrecoverable scenarios

## Rationale
The `exit` method should allow for proper cleanup (finally blocks, atexit handlers, buffer flushing) while the `panic` method should remain for immediate termination in catastrophic failures.