### PR TITLE
docs: Document -R and -i flag dependency in rnstatus usage

### DIFF
--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -355,11 +355,14 @@ Filter output to only show some interfaces:
     -s SORT, --sort SORT  sort interfaces by [rate, traffic, rx, tx, announces, arx, atx, held]
     -r, --reverse         reverse sorting
     -j, --json            output in JSON format
-    -R hash               transport identity hash of remote instance to get status from
+    -R hash               transport identity hash of remote instance to get status from (requires -i)
     -i path               path to identity used for remote management
     -w seconds            timeout before giving up on remote queries
     -v, --verbose
 
+
+.. note::
+   When using ``-R`` to query a remote transport instance, you must also specify ``-i`` with the path to a management identity file that is authorized for remote management on the target system.
 
 The rnid Utility
 ====================


### PR DESCRIPTION
Add usage example and clarify that -R requires -i flag for remote transport instance status queries. Fixes confusion where users get "expected str, bytes or os.PathLike object, not NoneType" error when using -R without -i.

- Add remote status query example to Usage Examples section
- Update -R flag description to indicate -i requirement
- Add explanatory note about management identity authorization

Addresses user reported issue where documentation was unclear about mandatory flag combination for remote management functionality.

Part of a resolution for #792. There is still a validation issue that doesn't tell the user that `-i` is required when using `-R`.