### PR TITLE
Improve logging logic when autointerface times out

### DIFF
--- a/RNS/Interfaces/AutoInterface.py
+++ b/RNS/Interfaces/AutoInterface.py
@@ -417,7 +417,7 @@ class AutoInterface(Interface):
                     last_multicast_echo = self.multicast_echoes[ifname]
 
                 if now - last_multicast_echo > self.multicast_echo_timeout:
-                    if ifname in self.timed_out_interfaces and self.timed_out_interfaces[ifname] == False:
+                    if ifname not in self.timed_out_interfaces or self.timed_out_interfaces[ifname] == False:
                         self.carrier_changed = True
                         RNS.log("Multicast echo timeout for "+str(ifname)+". Carrier lost.", RNS.LOG_WARNING)
                     self.timed_out_interfaces[ifname] = True


### PR DESCRIPTION
The way the logic for timeouts in the autointerface is currently handled is flawed I think. We're never printing a warning the first time a timeout happens. This is especially problematic when the interface never worked in the first place, like when you have a strict firewall, because nothing is printed on the logs to help the user figure it out. This commit fixes this.