### PR TITLE
change exit method in rncp

### DIFF
--- a/RNS/Utilities/rncp.py
+++ b/RNS/Utilities/rncp.py
@@ -104,7 +104,7 @@ def listen(configdir, verbosity = 0, quietness = 0, allowed = [], display_identi
     if display_identity:
         print("Identity     : "+str(identity))
         print("Listening on : "+RNS.prettyhexrep(destination.hash))
-        RNS.exit(0)
+        exit(0)
 
     if disable_auth:
         allow_all = True


### PR DESCRIPTION
resolves issue #959, and aligns the exit method used with that in rnx.

I noticed that rnx uses `exit(x)` in all instances, whilst rncp always uses `RNS.exit(x)`, but I've opted to only alter the instance after printing, as that was the only change needed to resolve this specific issue.