### PR TITLE
Added custom identity support to rncp utility

### DIFF
--- a/docs/manual/using.html
+++ b/docs/manual/using.html
@@ -791,10 +791,15 @@ and simply running the program in listener mode:</p>
 <div class="highlight-text notranslate"><div class="highlight"><pre><span></span>$ rncp --fetch ~/path/to/file.tgz 73cbd378bb0286ed11a707c13447bb1e
 </pre></div>
 </div>
+<p>The default identity file is stored in <code class="docutils literal notranslate"><span class="pre">~/.reticulum/identities/rncp</span></code>, but you can use
+another one, which will be created if it does not already exist</p>
+<div class="highlight-text notranslate"><div class="highlight"><pre><span></span>$ rncp ~/path/to/file.tgz 73cbd378bb0286ed11a707c13447bb1e -i /path/to/identity
+</pre></div>
+</div>
 <p><strong>All Command-Line Options</strong></p>
 <div class="highlight-text notranslate"><div class="highlight"><pre><span></span>usage: rncp [-h] [--config path] [-v] [-q] [-S] [-l] [-F] [-f]
             [-j path] [-b seconds] [-a allowed_hash] [-n] [-p]
-            [-w seconds] [--version] [file] [destination]
+            [-i identity] [-w seconds] [--version] [file] [destination]
 
 Reticulum File Transfer Utility
 
@@ -819,6 +824,7 @@ options:
   -a allowed_hash       allow this identity (or add in ~/.rncp/allowed_identities)
   -n, --no-auth         accept requests from anyone
   -p, --print-identity  print identity and destination info and exit
+  -i identity           path to identity to use
   -w seconds            sender timeout before giving up
   -P, --phy-rates       display physical layer transfer rates
   --version             show program&#39;s version number and exit

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -619,13 +619,20 @@ Or fetch a file from the remote system:
 
   $ rncp --fetch ~/path/to/file.tgz 73cbd378bb0286ed11a707c13447bb1e
 
+The default identity file is stored in ``~/.reticulum/identities/rncp``, but you can use
+another one, which will be created if it does not already exist
+
+.. code:: text
+
+  $ rncp ~/path/to/file.tgz 73cbd378bb0286ed11a707c13447bb1e -i /path/to/identity
+
 **All Command-Line Options**
 
 .. code:: text
 
   usage: rncp [-h] [--config path] [-v] [-q] [-S] [-l] [-F] [-f]
               [-j path] [-b seconds] [-a allowed_hash] [-n] [-p]
-              [-w seconds] [--version] [file] [destination]
+              [-i identity] [-w seconds] [--version] [file] [destination]
 
   Reticulum File Transfer Utility
 
@@ -650,6 +657,7 @@ Or fetch a file from the remote system:
     -a allowed_hash       allow this identity (or add in ~/.rncp/allowed_identities)
     -n, --no-auth         accept requests from anyone
     -p, --print-identity  print identity and destination info and exit
+    -i identity           path to identity to use
     -w seconds            sender timeout before giving up
     -P, --phy-rates       display physical layer transfer rates
     --version             show program's version number and exit


### PR DESCRIPTION
Previously, rncp only used the default identity path.
This change adds the ability to specify a custom identity file.
This has been implemented following the same pattern as in rnx.

Added flag:
```-i``` : Allows the user to specify a path to a identity file