### PR TITLE
Added monitor mode to rnstatus

### DIFF
--- a/docs/manual/using.html
+++ b/docs/manual/using.html
@@ -555,7 +555,7 @@ Reticulum Transport Instance &lt;5245a8efe1788c6a1cd36144a270e13b&gt; running
 <p><strong>All Command-Line Options</strong></p>
 <div class="highlight-text notranslate"><div class="highlight"><pre><span></span>usage: rnstatus [-h] [--config CONFIG] [--version] [-a] [-A]
                 [-l] [-s SORT] [-r] [-j] [-R hash] [-i path]
-                [-w seconds] [-v] [filter]
+                [-w seconds] [-v] [-m] [-mi seconds] [filter]
 
 Reticulum Network Stack Status
 
@@ -576,6 +576,9 @@ options:
   -i path               path to identity used for remote management
   -w seconds            timeout before giving up on remote queries
   -v, --verbose
+  -m, --monitor         continuously monitor status
+  -mi seconds, --monitor-interval seconds
+                        refresh interval for monitor mode (default: 1)
 </pre></div>
 </div>
 <div class="admonition note">

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -339,7 +339,7 @@ Filter output to only show some interfaces:
 
   usage: rnstatus [-h] [--config CONFIG] [--version] [-a] [-A]
                   [-l] [-s SORT] [-r] [-j] [-R hash] [-i path]
-                  [-w seconds] [-v] [filter]
+                  [-w seconds] [-v] [-m] [-mi seconds] [filter]
 
   Reticulum Network Stack Status
 
@@ -360,6 +360,9 @@ Filter output to only show some interfaces:
     -i path               path to identity used for remote management
     -w seconds            timeout before giving up on remote queries
     -v, --verbose
+    -m, --monitor         continuously monitor status
+    -mi seconds, --monitor-interval seconds
+                          refresh interval for monitor mode (default: 1)
 
 
 .. note::


### PR DESCRIPTION
This PR adds a real-time monitoring mode to rnstatus, allowing users to continuously observe interface status and traffic statistics.

Added flags:
```-m``` / ```--monitor```: Enables continuous status updates
```-mi``` / ```--monitor-interval```: Configurable refresh interval (default: 1 second)